### PR TITLE
Update an ICLR 2025 paper

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025/02/16
+
+Add "GS-CPR: Efficient Camera Pose Refinement via 3D Gaussian Splatting"
+
 ### 2025/02/04
 
 Add "PhiP-G: Physics-Guided Text-to-3D Compositional Scene Generation"

--- a/README.md
+++ b/README.md
@@ -2909,10 +2909,10 @@
 - **🔗 链接**：[[中英摘要](./abs/2408.11447.md)] [[arXiv:2408.11447](https://arxiv.org/abs/2408.11447)] [[Code](https://github.com/GANWANSHUI/GaussianOcc)]
 - **📝 说明**：
 
-#### [472] GSLoc: Efficient Camera Pose Refinement via 3D Gaussian Splatting
-- **🧑‍🔬 作者**：Changkun Liu, Shuai Chen, Yash Bhalgat, Siyan Hu, Zirui Wang, Ming Cheng, Victor Adrian Prisacariu, Tristan Braud
+#### [472] GS-CPR: Efficient Camera Pose Refinement via 3D Gaussian Splatting
+- **🧑‍🔬 作者**：Changkun Liu, Shuai Chen, Yash Bhalgat, Siyan Hu, Ming Cheng, Zirui Wang, Victor Adrian Prisacariu, Tristan Braud
 - **🏫 单位**：HKUST ⟐ University of Oxford ⟐ Dartmouth College
-- **🔗 链接**：[[中英摘要](./abs/2408.11085.md)] [[arXiv:2408.11085](https://arxiv.org/abs/2408.11085)] [Code]
+- **🔗 链接**：[[中英摘要](./abs/2408.11085.md)] [[arXiv:2408.11085](https://arxiv.org/abs/2408.11085)] [[Code]](https://github.com/XRIM-Lab/GS-CPR)
 - **📝 说明**：
 
 #### [473] ShapeSplat: A Large-scale Dataset of Gaussian Splats and Their Self-Supervised Pretraining


### PR DESCRIPTION
During the ICLR review process, GSLoc changed to GS-CPR in the camera-ready version according to the comments of reviewers. GS-CPR is accepted to ICLR 2025 and release the code